### PR TITLE
Added autofocus to name input on game join screen

### DIFF
--- a/app/views/join.erb
+++ b/app/views/join.erb
@@ -7,7 +7,7 @@
     <h1>Join Game</h1>
     <form action="/game" method="post">
       <label for="name">Enter name:</label>
-      <input type="text" name="name">
+      <input type="text" name="name" autofocus>
       <button type="submit">Submit</button>
     </form>
 


### PR DESCRIPTION
#### What's this PR do?
Adds autofocus to name input on game join screen

##### Background context
I'm lazy and didn't want to have to click in the input every time I test the game

#### How should this be manually tested?
load game, enter name, hit return