### PR TITLE
Hardcode webpack dev server port.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,7 @@
 require File.expand_path('../app/app.rb', __FILE__)
 
 if ENV["RACK_ENV"] == "development"
-  pid = Process.spawn("./node_modules/.bin/webpack-dev-server")
+  pid = Process.spawn("./node_modules/.bin/webpack-dev-server --port 8081")
   Process.detach(pid)
   puts "Started Webpack dev server #{pid}"
 end


### PR DESCRIPTION
#### What's this PR do?
Sometimes the webpack dev server process isn't being killed when running
development environment.

This leads to a new server being spawned on next boot but on a different
port. Hopefully this hack will at least lead to an error when binding to
to 8081 so that developer knows they need to manually kill node process.

