### PR TITLE
Refactor connection class to return ID for player.

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -24,7 +24,8 @@ module Hammeroids
         channel = EM::Channel.new
         EventMachine::WebSocket.start(host: @socket_host, port: @socket_port) do |ws|
           ws.onopen do |handshake|
-            Hammeroids::Connection.new(ws, channel)
+            id = Hammeroids::Connection.new(ws, channel).setup!
+            Hammeroids::Player.create(id, name: "Player #{id}")
           end
 
         end
@@ -85,7 +86,7 @@ module Hammeroids
     end
 
     post '/game' do
-      @player = Hammeroids::Player.create(name: params["name"])
+      @name = params["name"]
       erb :game
     end
 

--- a/app/lib/connection.rb
+++ b/app/lib/connection.rb
@@ -3,14 +3,22 @@ module Hammeroids
     def initialize(socket, channel)
       @socket = socket
       @channel = channel
-      @id = channel.subscribe { |message| @socket.send(message) }
+    end
+
+    def setup!
+      @socket.send(%({"type":"welcome", "id": #{id}}))
       @socket.onmessage { |message| process(message) }
       @socket.onclose { unsubscribe }
-      @socket.send(%({"type":"welcome", "id": #{@id}}))
+    end
+
+    private
+
+    def id
+      @id ||= @channel.subscribe { |message| @socket.send(message) }
     end
 
     def unsubscribe
-      @channel.unsubscribe(@id)
+      @channel.unsubscribe(id)
     end
 
     # deals with incoming data

--- a/app/lib/player.rb
+++ b/app/lib/player.rb
@@ -4,15 +4,15 @@ module Hammeroids
     attr_accessor :id, :name
     LIST_NAME = "players".freeze
 
-    def self.create(name: "Guest")
-      player = new(name: name)
+    def self.create(id, name: "Guest")
+      player = new(id, name: name)
       player.create
       player
     end
 
-    def initialize(name: "Guest")
+    def initialize(id, name: "Guest")
+      @id = id
       @name = name
-      @id = SecureRandom.uuid
     end
 
     def create

--- a/app/views/game.erb
+++ b/app/views/game.erb
@@ -7,12 +7,12 @@
   </style>
   </head>
 
-  <body data-player-uuid="<%= @player.id %>">
+  <body>
     <div class="container">
       <div class="row">
         <div class="twelve columns">
           <h1>Game!</h1>
-          <p><strong>Name:</strong> <span id="name"><%= @player.name %></span></p>
+          <p><strong>Name:</strong> <span id="name"><%= @name %></span></p>
         </div>
       </div>
 

--- a/spec/lib/player_spec.rb
+++ b/spec/lib/player_spec.rb
@@ -1,11 +1,13 @@
 require 'spec_helper'
 
+
 RSpec.describe Hammeroids::Player do
   describe '.create' do
-    subject { described_class.create }
+    subject { described_class.create(id) }
 
     context "new player" do
       let(:mock_redis) { instance_double("Redis", lpush: nil) }
+      let(:id) { Faker::Number.between(1, 100) }
 
       before do
         allow(Redis).to receive(:new).and_return(mock_redis)
@@ -23,7 +25,8 @@ RSpec.describe Hammeroids::Player do
   end
 
   describe '#create' do
-    subject { described_class.new.create }
+    subject { described_class.new(id).create }
+    let(:id) { Faker::Number.between(1, 100) }
 
     context "new player" do
       let(:mock_redis) { instance_double("Redis", lpush: nil) }
@@ -40,15 +43,17 @@ RSpec.describe Hammeroids::Player do
   end
 
   describe '#id' do
-    subject { described_class.new.id }
+    subject { described_class.new(id).id }
+    let(:id) { Faker::Number.between(1, 100) }
 
-    it "returns UUID" do
-      expect(subject).to match(/[a-z0-9\-]{36}/)
+    it "returns ID" do
+      expect(subject).to eq id
     end
   end
 
   describe '#to_h' do
-    subject { described_class.new(name: name).to_h }
+    subject { described_class.new(id, name: name).to_h }
+    let(:id) { Faker::Number.between(1, 100) }
 
     context "with name" do
       let(:name) { Faker::Name.name }
@@ -60,13 +65,15 @@ RSpec.describe Hammeroids::Player do
   end
 
   describe '#to_json' do
-    subject { described_class.new(name: name).to_json }
+    subject { described_class.new(id, name: name).to_json }
+    let(:id) { Faker::Number.between(1, 100) }
 
     context "with name" do
       let(:name) { Faker::Name.name }
 
       it "returns a JSON serialised player" do
         expect(subject).to include name
+        expect(subject).to include id.to_s
       end
 
       it "serialises to JSON String" do

--- a/spec/requests/app_controller_spec.rb
+++ b/spec/requests/app_controller_spec.rb
@@ -12,12 +12,7 @@ RSpec.describe "Hammeroids::App", type: :request do
 
   describe "POST /game" do
     let(:path) { "/game" }
-    let(:name) {Faker::Name.name}
-    let(:mock_player) { instance_double("Hammeroids::Player", id: SecureRandom.uuid, name: name) }
-
-    before do
-      allow(Hammeroids::Player).to receive(:create).and_return(mock_player)
-    end
+    let(:name) { Faker::Name.name }
 
     context "with params" do
       let(:params) do
@@ -29,13 +24,8 @@ RSpec.describe "Hammeroids::App", type: :request do
         expect(last_response.successful?).to eql true
       end
 
-      it "is contains player UUID data attribute" do
-        post path, params: params
-        expect(last_response.body).to match(/data\-player\-uuid\=\"[a-z0-9\-]{36}\"/)
-      end
-
       it "is contains player name data attribute" do
-        post path, params: params
+        post path, params
         expect(last_response.body).to include name
       end
     end


### PR DESCRIPTION
#### What's this PR do?

Tidied up the `Connection` constructor a bit.

Moves player creation to socket connection, uses the socket channel subscriber ID as player ID. Means the ID is an integer, but i think that's OK for now.

##### Background context

Want to get everything in sync between serverside player creation and the socket channel subscription. This change does mean that the chosen player name is not passed to the `Hammeroids::Player` object anymore. Will hook this up later.
