### PR TITLE
Broadcast lobby on join and update in view.

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -26,6 +26,7 @@ module Hammeroids
           connection.onopen do |handshake|
             player = Hammeroids::Player.new(connection, channel)
             player.join
+            channel.push(Hammeroids::Lobby.new.to_json)
           end
 
         end

--- a/app/javascript/src/game/sockets/message_router.js
+++ b/app/javascript/src/game/sockets/message_router.js
@@ -1,0 +1,37 @@
+import {Lobby} from'../ui/lobby';
+
+const CLASSES = {
+  'lobby': Lobby,
+};
+
+export class MessageRouter {
+  constructor(event) {
+    this.event = event;
+  }
+
+  action () {
+    if (this.klass !== undefined) {
+      this.klass_instance.update();
+    }
+  }
+
+  get data () {
+    return JSON.parse(this.event.data);
+  }
+
+  get klass () {
+    return CLASSES[this.type]
+  }
+
+  get klass_instance () {
+    return new this.klass(this.payload);
+  }
+
+  get payload () {
+    return this.data.payload;
+  }
+
+  get type () {
+    return this.data.type;
+  }
+}

--- a/app/javascript/src/game/sockets/sockets.js
+++ b/app/javascript/src/game/sockets/sockets.js
@@ -1,3 +1,4 @@
+import {MessageRouter} from './message_router.js';
 import {Ship} from '../entities/ship.js';
 import {Slug} from '../entities/slug.js';
 
@@ -16,6 +17,8 @@ export class Sockets {
   }
 
   onMessage = (event) => {
+    const router = new MessageRouter(event)
+    router.action();
     const data = JSON.parse(event.data);
     if(data.type == 'welcome') {
       this.id = data.id;

--- a/app/javascript/src/game/ui/lobby.js
+++ b/app/javascript/src/game/ui/lobby.js
@@ -1,0 +1,31 @@
+/*jshint esversion: 6 */
+export class Lobby {
+  constructor(payload, elementId="lobby") {
+    this.payload = payload;
+    this.elementId = elementId;
+  }
+
+  update () {
+    this.clearParent();
+    this.players.forEach((player) => {
+      var div = document.createElement("div");
+      var text = document.createTextNode(`${player.name} (${player.id})`);
+      div.appendChild(text);
+      this.parentElement.appendChild(div)
+    })
+  }
+
+  clearParent () {
+    while (this.parentElement.firstChild) {
+      this.parentElement.removeChild(this.parentElement.firstChild);
+    }
+  }
+
+  get parentElement () {
+    return document.getElementById(this.elementId);
+  }
+
+  get players () {
+    return this.payload.players
+  }
+}

--- a/app/lib/lobby.rb
+++ b/app/lib/lobby.rb
@@ -13,22 +13,26 @@ module Hammeroids
       redis.del(LIST_KEY)
     end
 
-    def to_h
-      { type: "lobby", payload: { players: JSON.parse(players, symbolize_names: true) } }
-    end
-
     def to_json
-      to_h.to_json
+      JSON.generate(to_h)
     end
 
     private
 
     def players
+      players_json.map { |player_json| JSON.parse(player_json) }
+    end
+
+    def players_json
       redis.lrange(LIST_KEY, 0, -1)
     end
 
     def redis
       @redis ||= Redis.new(url: ENV.fetch("REDIS_URL"))
+    end
+
+    def to_h
+      { "type": "lobby", "payload": { "players": players } }
     end
   end
 end

--- a/app/views/game.erb
+++ b/app/views/game.erb
@@ -21,6 +21,14 @@
           <canvas id="canvas"></canvas>
         </div>
       </div>
+
+      <div class="row">
+        <div class="twelve columns">
+          <h3>Lobby</h3>
+          <div id="lobby">
+          </ul>
+        </div>
+      </div>
     </div>
 
     <script type="text/javascript" src="<%= settings.pack_location %>main.js" ></script>

--- a/spec/lib/lobby_spec.rb
+++ b/spec/lib/lobby_spec.rb
@@ -15,19 +15,25 @@ RSpec.describe Hammeroids::Lobby do
     end
   end
 
-  describe "#to_h" do
-    subject { described_class.new.to_h }
-    let(:mock_redis) { instance_double("Redis", lrange: JSON.generate(players)) }
+  describe "#to_json" do
+    subject { described_class.new.to_json }
+    let(:mock_redis) { instance_double("Redis", lrange: players) }
     let(:players) do
-      (1..10).map { |id| { id: id, name: Faker::RickAndMorty.character } }
+      (1..10).map { |id| JSON.generate("id" => id, "name" => Faker::RickAndMorty.character) }
     end
+    let(:parsed_subject) { JSON.parse(subject) }
 
     before do
       allow(Redis).to receive(:new).and_return(mock_redis)
     end
 
-    it "returns an hash containing lobby data" do
-      expect(subject).to eq(type: "lobby", payload: { players: players })
+    it "contains correct keys" do
+      expect(parsed_subject.keys).to include("type", "payload")
+    end
+
+    it "payload contains array of players" do
+      players = parsed_subject.dig("payload", "players")
+      expect(players).to include(hash_including("id", "name"))
     end
   end
 end


### PR DESCRIPTION
#### What's this PR do?

**Note:** players are not yet removed from the lobby on disconnect and all lobby players are called guest. So there's duplication and weirdness.

Broadcasts the lobby player list after a new player joins.

Processes incoming lobby type messages and updates the lobby in game view. Their id is the connection ID.


#### Screenshots
![screenshot 2019-03-06 at 15 35 37](https://user-images.githubusercontent.com/847787/53893177-96d4b200-4025-11e9-871f-7f73e32049c8.png)
