### PR TITLE
Remove player from lobby and broadcast on disconnect.

### DIFF
--- a/app/lib/lobby.rb
+++ b/app/lib/lobby.rb
@@ -9,6 +9,10 @@ module Hammeroids
       redis.lpush(LIST_KEY, player_json)
     end
 
+    def remove(player_json)
+      redis.lrem(LIST_KEY, 0, player_json)
+    end
+
     def clear
       redis.del(LIST_KEY)
     end

--- a/app/lib/player.rb
+++ b/app/lib/player.rb
@@ -14,6 +14,14 @@ module Hammeroids
       Hammeroids::Lobby.new.add(to_json)
     end
 
+    def leave
+      Hammeroids::Lobby.new.remove(to_json)
+    end
+
+    def subscription_id
+      @subscription_id ||= Hammeroids::Players::Subscription.new(@connection, @channel).create
+    end
+
     private
 
     def to_h
@@ -25,10 +33,6 @@ module Hammeroids
 
     def to_json
       to_h.to_json
-    end
-
-    def subscription_id
-      @subscription_id ||= Hammeroids::Players::Subscription.new(@connection, @channel).create
     end
   end
 end

--- a/app/lib/players/subscription.rb
+++ b/app/lib/players/subscription.rb
@@ -9,8 +9,6 @@ module Hammeroids
 
       def create
         @connection.send(%({"type":"welcome", "id": #{id}}))
-        @connection.onmessage { |message| process(message) }
-        @connection.onclose { unsubscribe }
         id
       end
 
@@ -18,15 +16,6 @@ module Hammeroids
 
       def id
         @id ||= @channel.subscribe { |message| @connection.send(message) }
-      end
-
-      def unsubscribe
-        @channel.unsubscribe(id)
-      end
-
-      # deals with incoming data
-      def process(message)
-        @channel << %(#{message}) rescue nil
       end
     end
   end

--- a/spec/lib/player_spec.rb
+++ b/spec/lib/player_spec.rb
@@ -27,4 +27,30 @@ RSpec.describe Hammeroids::Player do
       end
     end
   end
+
+  describe "#leave" do
+    subject { described_class.new(connection, channel, name: name).leave}
+    let(:mock_redis) { instance_double("Redis", lrem: nil) }
+    let(:connection) { instance_double("EventMachine::WebSocket::Connection") }
+    let(:channel) { instance_double("EventMachine::Channel") }
+    let(:mock_subscription) { instance_double("Hammeroids::Players::Subscription", create: subscription_id) }
+
+    context "already subscribed" do
+      let(:subscription_id) { Faker::Number.between(1, 100) }
+
+      before do
+        allow(Hammeroids::Players::Subscription).to receive(:new).and_return(mock_subscription)
+        allow(Redis).to receive(:new).and_return(mock_redis)
+      end
+
+      context "name" do
+        let(:name) { Faker::RickAndMorty.character }
+
+        it "Removes the player JSON from redis players list" do
+          subject
+          expect(mock_redis).to have_received(:lrem).with("players", 0, include(subscription_id.to_s, name))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What's this PR do?

Closes https://github.com/boakfriends/hammeroids/issues/60

Refactors some the connection events out of the Subscription class and
back up in to the main Socket block, this makes it a bit clearer to see
the lifecycle of the connection.

When a connection disconnects the player is removed from the lobby and
updated lobby is broadcast to all connections in the channel.

##### Background context

Players were hanging around in the lobby after disconnect.

#### How should this be manually tested?

Join the game in two windows, see both players listed in lobby. Close one window and the lobby will update to just show the first player.

#### Screenshots
![lobby-leave](https://user-images.githubusercontent.com/847787/53897696-95f44e00-402e-11e9-8976-57af35e766f3.gif)
