### PR TITLE
Move Subscription welcome into Event class.

### DIFF
--- a/app/lib/players/subscription.rb
+++ b/app/lib/players/subscription.rb
@@ -2,17 +2,25 @@ module Hammeroids
   module Players
     # Subscribes @connection to @channel and defines onmessage and onclose events.
     class Subscription
+      EVENTS = [
+        Hammeroids::Subscriptions::Events::Welcome
+      ].freeze
+
       def initialize(connection, channel)
         @connection = connection
         @channel = channel
       end
 
       def create
-        @connection.send(%({"type":"welcome", "id": #{id}}))
+        create_events
         id
       end
 
       private
+
+      def create_events
+        EVENTS.each { |event| event.new(@connection, id).create }
+      end
 
       def id
         @id ||= @channel.subscribe { |message| @connection.send(message) }

--- a/app/lib/subscriptions/events/welcome.rb
+++ b/app/lib/subscriptions/events/welcome.rb
@@ -1,0 +1,27 @@
+module Hammeroids
+  module Subscriptions
+    module Events
+      # Welcome event, sent when Subscription is created.
+      class Welcome
+        def initialize(connection, id)
+          @connection = connection
+          @id = id
+        end
+
+        def create
+          @connection.send(to_json)
+        end
+
+        private
+
+        def attributes
+          { type: "welcome", id: @id }
+        end
+
+        def to_json
+          JSON.generate(attributes)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/subscriptions/events/welcome_spec.rb
+++ b/spec/lib/subscriptions/events/welcome_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe Hammeroids::Subscriptions::Events::Welcome do
+  describe "#create" do
+    subject { described_class.new(connection, id).create }
+
+    context "subscribed" do
+      let(:connection) { instance_double(EventMachine::WebSocket::Connection, send: nil) }
+
+      let(:id) { Faker::Number.between(1, 100) }
+
+      it "should send the JSON" do
+        subject
+        expect(connection).to have_received(:send).with("{\"type\":\"welcome\",\"id\":#{id}}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?

Moves the Welcome JSON out of the `Subscription` object and into it's own
class. Adds support for multiple subscription events should we need them
later.

##### Background context

Some refactoring ahead of fixing the name in lobby issue.

I think this is a bit clearer. The `Subscription` object is now only responsible for subscribing the `Connection` to the `Channel`.
