### PR TITLE
Send player name on welcome

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -1,5 +1,4 @@
-%w[require_all 
-   em-websocket thin redis sinatra].each { |library| require library }
+%w[require_all active_support/core_ext/hash/keys active_support/inflector em-websocket thin redis sinatra].each { |library| require library }
 ENV['RACK_ENV'] ||= 'development'
 require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'
@@ -31,6 +30,7 @@ module Hammeroids
           end
 
           connection.onmessage do |message|
+            Hammeroids::Sockets::MessageRouter.new(connection, message).action
             channel.push(message)
           end
 

--- a/app/javascript/src/game/sockets/messages/player_name.js
+++ b/app/javascript/src/game/sockets/messages/player_name.js
@@ -1,0 +1,22 @@
+export class PlayerName {
+  constructor(ws) {
+    this.ws = ws;
+  }
+
+  update() {
+    this.ws.send(this.messageString)
+  }
+
+  get messageString() {
+    return JSON.stringify(this.message);
+  }
+
+  get message() {
+    return { 'type': 'player_name', 'method': { 'name': 'update', 'args': { 'name': this.playerName } } };
+  }
+
+  get playerName() {
+    return document.body.dataset.playerName;
+  }
+}
+

--- a/app/javascript/src/game/sockets/sockets.js
+++ b/app/javascript/src/game/sockets/sockets.js
@@ -1,4 +1,5 @@
 import {MessageRouter} from './message_router.js';
+import {PlayerName} from './messages/player_name.js';
 import {Ship} from '../entities/ship.js';
 import {Slug} from '../entities/slug.js';
 
@@ -20,6 +21,8 @@ export class Sockets {
     const data = JSON.parse(event.data);
     if(data.type == 'welcome') {
       this.id = data.id;
+      const player_name = new PlayerName(this.ws);
+      player_name.update();
     } else if(data.type == 'update' && this.id != data.id) {
       if(!this.networkObjects[data.id]) {
         this.networkObjects[data.id] = new Ship(data.data.position.x, data.data.position.y);

--- a/app/lib/sockets/message_router.rb
+++ b/app/lib/sockets/message_router.rb
@@ -1,0 +1,41 @@
+module Hammeroids
+  module Sockets
+    # Routes inbound messages to the correct class/method.
+    class MessageRouter
+      ROUTABLE = %w[player_name].freeze
+
+      def initialize(connection, message_json)
+        @connection = connection
+        @message_json = message_json
+      end
+
+      def action
+        return unless ROUTABLE.include? type
+
+        klass.new(@connection).send(method.to_sym, **args)
+      end
+
+      private
+
+      def args
+        message.dig("method", "args").symbolize_keys
+      end
+
+      def klass
+        "Hammeroids::Sockets::Messages::#{type.camelize}".constantize
+      end
+
+      def method
+        message.dig("method", "name")
+      end
+
+      def message
+        @message ||= JSON.parse(@message_json)
+      end
+
+      def type
+        message["type"]
+      end
+    end
+  end
+end

--- a/app/lib/sockets/messages/base.rb
+++ b/app/lib/sockets/messages/base.rb
@@ -1,0 +1,12 @@
+module Hammeroids
+  module Sockets
+    module Messages
+      # Base class for messages
+      class Base
+        def initialize(connection)
+          @connection = connection
+        end
+      end
+    end
+  end
+end

--- a/app/lib/sockets/messages/player_name.rb
+++ b/app/lib/sockets/messages/player_name.rb
@@ -1,0 +1,13 @@
+module Hammeroids
+  module Sockets
+    module Messages
+      # Sets player name in Lobby
+      class PlayerName < Base
+        def update(**args)
+          # TODO: update player name in redis
+          puts args
+        end
+      end
+    end
+  end
+end

--- a/app/views/game.erb
+++ b/app/views/game.erb
@@ -7,7 +7,7 @@
   </style>
   </head>
 
-  <body data-settings-base-socket-url="<%= Hammeroids::Settings.base_socket_url %>">
+  <body data-settings-base-socket-url="<%= Hammeroids::Settings.base_socket_url %>" data-player-name="<%= @name %>">
     <div class="container">
       <div class="row">
         <div class="twelve columns">

--- a/spec/lib/sockets/message_router_spec.rb
+++ b/spec/lib/sockets/message_router_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+RSpec.describe Hammeroids::Sockets::MessageRouter do
+  describe "#action" do
+    subject { described_class.new(connection, message).action }
+
+    context "connection" do
+      let(:connection) { double("EventMachine::Connection") }
+
+      context "valid message class" do
+        let(:message) do
+          JSON.generate(
+            {
+              "type" => "player_name",
+              "method" =>
+                {
+                  "name" => "update",
+                  "args" => {
+                    "name" => "rudiger"
+                  }
+                }
+            }
+          )
+        end
+
+        let(:mock_messages_name) { instance_double(Hammeroids::Sockets::Messages::PlayerName, update: nil) }
+
+        before do
+          allow(Hammeroids::Sockets::Messages::PlayerName).to receive(:new).with(connection).and_return(mock_messages_name)
+        end
+
+        it "should call the right class" do
+          subject
+          expect(mock_messages_name).to have_received(:update).with(name: "rudiger")
+        end
+      end
+
+      context "invalid message class" do
+        let(:message) do
+          JSON.generate(
+            {
+              "type" => "boak",
+              "method" =>
+                {
+                  "name" => "update",
+                  "args" => {
+                    "name" => "rudiger"
+                  }
+                }
+            }
+          )
+        end
+
+        it "does nothing" do
+          expect { subject }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?

Makes some progress on https://github.com/boakfriends/hammeroids/issues/72 but am opening this to break up the work a bit.

Adds a serverside message router, this routes the message to the right service object, at the moment just `PlayerName` which does nothing except log out its args.

Adds a JS object to send the players name over to the server in response to the welcome message. This is a bit untidy at the moment, but will work on.

##### Background context

The player name isn't shown in the lobby.

#### Screenshots
![set_name](https://user-images.githubusercontent.com/847787/54610276-8f150480-4a4c-11e9-8428-1b8969ba4493.gif)

