### PR TITLE
Make Player ID attribute available in message block.

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -24,14 +24,15 @@ module Hammeroids
           player = Hammeroids::Player.new
 
           connection.onopen do |handshake|
-            Hammeroids::Channels::Subscription.new(connection, channel).create
+            player.id = Hammeroids::Channels::Subscription.new(connection, channel).create
           end
 
           connection.onmessage do |message|
             # TODO: refactor this once we have a better idea of all the events we'll be dealing with.
             message_h = JSON.parse(message).deep_symbolize_keys
             if message_h[:type] == "player"
-              player.update(message_h[:attributes])
+              player.name = message_h[:attributes][:name]
+              player.save
               Hammeroids::Channels::Lobby.new(channel).broadcast
             end
             channel.push(message)

--- a/app/lib/channels/subscription.rb
+++ b/app/lib/channels/subscription.rb
@@ -10,7 +10,7 @@ module Hammeroids
 
       def create
         @connection.send(json)
-        @connection
+        id
       end
 
       private

--- a/app/lib/player.rb
+++ b/app/lib/player.rb
@@ -1,7 +1,7 @@
 module Hammeroids
   # Represents a player, stores attributes in redis.
   # Class to can retrieve a list of players
-  Player = Struct.new(:name) do
+  class Player
     class << self
       def all
         redis.smembers("players").map { |player_json| JSON.parse(player_json) }
@@ -12,13 +12,19 @@ module Hammeroids
       end
     end
 
+    attr_accessor :id, :name
+
+    def initialize(id: nil, name: "Guest")
+      @id = id
+      @name = name
+    end
+
     def delete
       redis.srem("players", to_json)
     end
 
-    def update(**attributes)
-      @name = attributes[:name]
-      save
+    def save
+      redis.sadd("players", to_json)
     end
 
     private
@@ -27,12 +33,8 @@ module Hammeroids
       @redis ||= Redis.new(url: ENV.fetch("REDIS_URL"))
     end
 
-    def save
-      redis.sadd("players", to_json)
-    end
-
     def to_json
-      JSON.generate(name: @name)
+      JSON.generate(id: @id, name: @name)
     end
   end
 end

--- a/spec/lib/channels/subscription_spec.rb
+++ b/spec/lib/channels/subscription_spec.rb
@@ -6,15 +6,19 @@ RSpec.describe Hammeroids::Channels::Subscription do
 
     context "connection and channel" do
       let(:connection) { instance_double("EventMachine::Connection", send: nil) }
-      let(:channel) { instance_double("EM::Channel", subscribe: Faker::Number.between(1, 10)) }
+      let(:channel) { instance_double("EM::Channel", subscribe: subscription_id) }
 
-      it "returns the connection" do
-        expect(subject).to eq connection
-      end
+      context "successful" do
+        let(:subscription_id) { Faker::Number.between(1, 10) }
 
-      it "send welcome event to connection" do
-        subject
-        expect(connection).to have_received(:send).with(/welcome/)
+        it "returns the subscription ID" do
+          expect(subject).to eq subscription_id
+        end
+
+        it "send welcome event to connection" do
+          subject
+          expect(connection).to have_received(:send).with(/welcome/)
+        end
       end
     end
   end

--- a/spec/lib/player_spec.rb
+++ b/spec/lib/player_spec.rb
@@ -24,6 +24,47 @@ RSpec.describe Hammeroids::Player do
     end
   end
 
+  describe "attributes" do
+    subject { described_class.new(attributes) }
+
+    let(:attributes) do
+      {
+        id: Faker::Number.between(1,10),
+        name: Faker::TvShows::RickAndMorty.character
+      }
+    end
+
+    describe "#id" do
+      it "is not nil" do
+        expect(subject.id).not_to be_nil
+      end
+    end
+
+    describe "#id=(id)" do
+      let(:id) { Faker::Number.between(1,10) }
+
+      it "sets new id" do
+        subject.id = id
+        expect(subject.id).to eql id
+      end
+    end
+
+    describe "#name" do
+      it "is not nil" do
+        expect(subject.id).not_to be_nil
+      end
+    end
+
+    describe "#name=(name)" do
+      let(:name) { Faker::TvShows::RickAndMorty.character }
+
+      it "sets new name" do
+        subject.name = name
+        expect(subject.name).to eql name
+      end
+    end
+  end
+
   describe "#delete" do
     subject { described_class.new.delete }
 
@@ -41,16 +82,17 @@ RSpec.describe Hammeroids::Player do
     end
   end
 
-  describe "#update(attributes)" do
-    subject { described_class.new.update(attributes) }
+  describe "#save" do
+    subject { described_class.new(attributes).save }
 
     context "attributes" do
       let(:attributes) do
-        { name: name }
+        { id: id, name: name }
       end
 
-      context "name" do
+      context "id and name" do
         let(:name) { Faker::TvShows::RickAndMorty.character }
+        let(:id) { Faker::Number.between(1, 10) }
 
         context "not in  lobby" do
           let(:mock_redis) { instance_double("Redis", sadd: 1) }
@@ -61,7 +103,7 @@ RSpec.describe Hammeroids::Player do
 
           it "adds player JSON to players set, returns number of sets added" do
             expect(subject).to eq 1
-            expect(mock_redis).to have_received(:sadd).with("players", include(name))
+            expect(mock_redis).to have_received(:sadd).with("players", include("{\"id\":#{id},\"name\":\"#{name}\"}"))
           end
         end
       end


### PR DESCRIPTION
#### What's this PR do?

Refactors the Player object to simplify how it's name and ID values are
set. Use attr_accessor so that the Player#id value can later be used to
filter out some messages in the Connection#onmessage block.

##### Background context

This _should_ make it easier to inspect messages and remove them based on id.
