### PR TITLE
Added save and restore to context before drawing each object

### DIFF
--- a/app/javascript/src/game/drawing/drawer.js
+++ b/app/javascript/src/game/drawing/drawer.js
@@ -4,7 +4,9 @@ export class Drawer {
   }
 
   draw(context) {
+    context.save();
     Object.keys(this.params).forEach((key) => context[key] = this.params[key]);
     (this._draw || (() => {}))(context);
+    context.restore();
   }
 }

--- a/test/drawing/test_drawer.js
+++ b/test/drawing/test_drawer.js
@@ -12,7 +12,7 @@ describe('Drawer', function() {
         'font': 'bodacious'
       }
       const drawer = new Drawer(params);
-      const contextSpy = {};
+      const contextSpy = {save: sinon.spy(), restore: sinon.spy()};
       
       // When
       drawer.draw(contextSpy);
@@ -26,7 +26,7 @@ describe('Drawer', function() {
       // Given
       const drawer = new Drawer({});
       drawer._draw = sinon.spy();
-      const contextSpy = {};
+      const contextSpy = {save: sinon.spy(), restore: sinon.spy()};
       
       // When
       drawer.draw(contextSpy);

--- a/test/drawing/test_pathdrawer.js
+++ b/test/drawing/test_pathdrawer.js
@@ -17,7 +17,7 @@ describe('PathDrawer', function() {
         new Vector(0,0)
       ];
       const pathDrawer = new PathDrawer(path, params);
-      const contextSpy = {beginPath: sinon.spy(), moveTo: sinon.spy(), lineTo: sinon.spy(), closePath: sinon.spy(), stroke: sinon.spy()}
+      const contextSpy = {beginPath: sinon.spy(), moveTo: sinon.spy(), lineTo: sinon.spy(), closePath: sinon.spy(), stroke: sinon.spy(), save: sinon.spy(), restore: sinon.spy()}
       
       // When
       pathDrawer.draw(contextSpy);

--- a/test/drawing/test_textdrawer.js
+++ b/test/drawing/test_textdrawer.js
@@ -13,7 +13,7 @@ describe('TextDrawer', function() {
         x = 10,
         y = 10,
         textDrawer = new TextDrawer({'x': x, 'y': y}, text, params);
-      const contextSpy = {fillText: sinon.spy()}
+      const contextSpy = {fillText: sinon.spy(), save: sinon.spy(), restore: sinon.spy()}
 
       // When
       textDrawer.draw(contextSpy);


### PR DESCRIPTION
#### What's this PR do?
Adds save and restore to context before drawing.

##### Background context
Everything was taking the shadowBlur (and other attributes) from ship.js, causing drawing to slow down