### PR TITLE
Arrows - should be merged after #96

### DIFF
--- a/app/javascript/src/game/camera/camera.js
+++ b/app/javascript/src/game/camera/camera.js
@@ -1,4 +1,5 @@
 import {Vector} from '../physics/vector.js';
+import {Bounds} from '../physics/bounds.js';
 
 export class Camera {
   constructor(gameState) {
@@ -20,10 +21,10 @@ export class Camera {
   }
 
   getBounds() {
-    return [
+    return new Bounds(
       this.position.subtract(this.gameState.centrePoint),
       this.position.add(this.gameState.centrePoint)
-    ]
+    )
   }
 
 }

--- a/app/javascript/src/game/drawing/arrowdrawer.js
+++ b/app/javascript/src/game/drawing/arrowdrawer.js
@@ -1,0 +1,56 @@
+import {Drawer} from './drawer.js';
+import {PathDrawer} from './pathdrawer.js';
+import {TextDrawer} from './textdrawer.js';
+import {Vector} from '../physics/vector.js';
+
+const ARROW_OFFSET = 20,
+  ARROW_COLOUR = 'rgb(255, 135, 71)';
+
+export class ArrowDrawer extends Drawer {
+  constructor(position, bounds, number) {
+    super({fillStyle: 'blue'});
+    this.bounds = bounds;
+    this.path = [
+      new Vector(-2, 10),
+      new Vector(0, -10),
+      new Vector(2, 10),
+      new Vector(-2, 10)
+    ];
+    this.position = Vector.fromString(position);
+    this.number = number;
+  }
+
+  static withPositions(positions, bounds) {
+    const arrowPositions = {};
+    for(let position of positions) {
+      const newPosition = bounds.withinBoundsOffset(position, ARROW_OFFSET);
+      if(arrowPositions[newPosition]) {
+        arrowPositions[newPosition] = arrowPositions[newPosition] + 1;
+      } else {
+        arrowPositions[newPosition] = 1;
+      }
+    }
+    return Object.keys(arrowPositions).map(newPosition => new ArrowDrawer(newPosition, bounds, arrowPositions[newPosition]));
+  }
+
+  _draw = (context) => {
+    const centre = this.bounds.centrePoint();
+    const vectorToArrow = this.position.subtract(centre);
+    const angle = vectorToArrow.angle() + (90 * Math.PI / 180);
+    const newPath = [];
+    for (let vector of this.path) {
+      newPath.push(vector
+        .rotate(angle, {x: 0, y: 0})
+        .add(this.position));
+    }
+    const pathDrawer = new PathDrawer(newPath, {strokeStyle: ARROW_COLOUR});
+    pathDrawer.draw(context);
+    if(this.number > 1) {
+      new TextDrawer(this.position, this.number, {
+        'fillStyle': ARROW_COLOUR,
+        'font': "10px Arial",
+        'textAlign': "center"
+      }).draw(context);
+    }
+  }
+}

--- a/app/javascript/src/game/entities/dustparticle.js
+++ b/app/javascript/src/game/entities/dustparticle.js
@@ -11,10 +11,10 @@ export class DustParticle {
 
   update(bounds, delta) {
     if(!this.position) {
-      this.position = Vector.inBounds(bounds);
+      this.position = bounds.vectorWithinBounds();
     }
     this.position = this.position.subtract(delta.scale(this.z - 1));
-    this.position = this.position.wrapBounds(bounds);
+    this.position = bounds.wrapBounds(this.position);
   }
 
   getDrawer = () => {

--- a/app/javascript/src/game/entities/ship.js
+++ b/app/javascript/src/game/entities/ship.js
@@ -77,4 +77,8 @@ export class Ship {
   set path(path) {
     this._path = path;
   }
+
+  get velocity() {
+    return this.physics.velocity;
+  }
 }

--- a/app/javascript/src/game/physics/bounds.js
+++ b/app/javascript/src/game/physics/bounds.js
@@ -1,0 +1,50 @@
+import {Vector} from './vector.js';
+
+export class Bounds {
+  constructor(topLeft, bottomRight) {
+    this.topLeft = topLeft;
+    this.bottomRight = bottomRight;
+  }
+
+  /*
+  * Should return a vector within the given bounds, by "wrapping" from one edge to another 
+  */
+  wrapBounds(vector) {
+    let xTemp,yTemp;
+    xTemp = vector.x < this.topLeft.x ? this.bottomRight.x : vector.x > this.bottomRight.x ? this.topLeft.x : vector.x;
+    yTemp = vector.y > this.bottomRight.y ? this.topLeft.y : vector.y < this.topLeft.y ? this.bottomRight.y : vector.y;
+    return (xTemp == vector.x && yTemp == vector.y) ? vector : new Vector(xTemp, yTemp);
+  }
+
+  /*
+  * Should return a new vector at a random position within the given bounds
+  */
+  vectorWithinBounds() {
+    const xTemp = Math.random() * (this.bottomRight.x - this.topLeft.x) + this.topLeft.x;
+    const yTemp = Math.random() * (this.bottomRight.y - this.topLeft.y) + this.topLeft.y;
+    return new Vector(xTemp, yTemp);
+  }
+
+  /*
+  * Should return true if the given vector is within the given bounds
+  */
+  inBounds(vector){
+    return (vector.x > this.topLeft.x && vector.y > this.topLeft.y) && (vector.x < this.bottomRight.x && vector.y < this.bottomRight.y);
+  }
+
+  /*
+  * Should return a Vector of the centre point of these bounds
+  */
+  centrePoint() {
+    return new Vector(((this.bottomRight.x - this.topLeft.x) / 2) + this.topLeft.x, ((this.bottomRight.y - this.topLeft.y) / 2) + this.topLeft.y);
+  }
+
+  /*
+  * Should return a vector within the given bounds offest by the given amount
+  */
+  withinBoundsOffset(vector, offset) {
+    const x = vector.x - offset < this.topLeft.x ? this.topLeft.x + offset : vector.x + offset > this.bottomRight.x ? this.bottomRight.x - offset : vector.x;
+    const y = vector.y - offset < this.topLeft.y ? this.topLeft.y + offset : vector.y + offset > this.bottomRight.y ? this.bottomRight.y - offset : vector.y;
+    return new Vector(x, y);
+  }
+}

--- a/app/javascript/src/game/physics/physicshandler.js
+++ b/app/javascript/src/game/physics/physicshandler.js
@@ -94,4 +94,8 @@ export class PhysicsHandler {
     this.angle = state.angle;
   }
 
+  get velocity() {
+    return Math.sqrt(this.momentumVector.x * this.momentumVector.x + this.momentumVector.y * this.momentumVector.y);
+  }
+
 }

--- a/app/javascript/src/game/physics/vector.js
+++ b/app/javascript/src/game/physics/vector.js
@@ -44,21 +44,17 @@ export class Vector {
     return new Vector(this.x * scale, this.y * scale);
   }
 
-  wrapBounds(bounds) {
-    let xTemp,yTemp;
-    xTemp = this.x < bounds[0].x ? bounds[1].x : this.x > bounds[1].x ? bounds[0].x : this.x;
-    yTemp = this.y > bounds[1].y ? bounds[0].y : this.y < bounds[0].y ? bounds[1].y : this.y;
-    return (xTemp == this.x && yTemp == this.y) ? this : new Vector(xTemp, yTemp);
-  }
-
   toString() {
-    return `{x: ${this.x}, y: ${this.y}}`;
+    return `{"x": ${this.x}, "y": ${this.y}}`;
   }
 
-  static inBounds(bounds) {
-    const xTemp = Math.random() * (bounds[1].x - bounds[0].x) + bounds[0].x;
-    const yTemp = Math.random() * (bounds[1].y - bounds[0].y) + bounds[0].y;
-    return new Vector(xTemp, yTemp);
+  angle() {
+    return Math.atan2(this.y, this.x);
+  }
+
+  static fromString(string) {
+    const coords = JSON.parse(string);
+    return new Vector(coords.x, coords.y);
   }
 
 }

--- a/app/javascript/src/game/ui/elements/arrows.js
+++ b/app/javascript/src/game/ui/elements/arrows.js
@@ -1,0 +1,39 @@
+import {Ship} from '../../entities/ship.js';
+import {ArrowDrawer} from '../../drawing/arrowdrawer.js';
+
+export class Arrows {
+  constructor(objects, camera) {
+    this.objects = objects;
+    this.camera = camera;
+  }
+
+  draw(context) {
+    this.getArrows(this.objects)(this.camera).draw(context);
+  }
+
+  getArrows(objects) {
+    const ships = [];
+    for(let obj of objects) {
+      if(obj instanceof Ship) {
+        ships.push(obj);
+      }
+    }
+    return (camera) => {
+      const shipPositions = [];
+      for(let ship of ships) {
+        if(!camera.getBounds().inBounds(ship.getPosition())) {
+          shipPositions.push(ship.getPosition());
+        }
+      }
+      const drawer = {
+        draw: (context) => {
+          const arrowDrawers = ArrowDrawer.withPositions(shipPositions, camera.getBounds());
+          for(let arrowDrawer of arrowDrawers) {
+            arrowDrawer.draw(context);
+          }
+        }
+      }
+      return drawer;
+    }
+  }
+}

--- a/app/javascript/src/game/ui/gamedetails.js
+++ b/app/javascript/src/game/ui/gamedetails.js
@@ -1,0 +1,30 @@
+import {TextDrawer} from '../drawing/textdrawer.js';
+import {Vector} from '../physics/vector.js';
+
+export class GameDetails {
+  constructor(gameState) {
+    this.framerate = this.showFrameRate(Math.round(gameState.frameRate, 2));
+    this.velocity = gameState.playerShip.velocity.toFixed(2);
+  }
+
+  draw(context, camera) {
+    this.framerate(camera).draw(context);
+  }
+
+  showFrameRate(framerate) {
+    return (camera) => {
+      const params = {
+        fillStyle: 'white',
+        font: "10px Arial",
+        textAlign: "left"
+      };
+      const drawer = new TextDrawer(
+        new Vector(20, 10).add(camera.getBounds().topLeft),
+        `Framerate: ${framerate}\nVelocity: ${this.velocity}`,
+        params
+      );
+      return drawer;
+    }
+  }
+
+}

--- a/app/javascript/src/game/ui/gameui.js
+++ b/app/javascript/src/game/ui/gameui.js
@@ -1,0 +1,20 @@
+import {GameDetails} from './gamedetails.js';
+import {Arrows} from './elements/arrows.js';
+
+export class GameUi {
+  constructor(gameState, camera) {
+    this.gameState = gameState;
+    this.camera = camera;
+    this.arrows = new Arrows(gameState.getObjects(), camera);
+  }
+
+  draw(context) {
+    this.arrows.draw(context);
+  }
+
+  drawDetails(context) {
+    const gameDetails = new GameDetails(this.gameState);
+    gameDetails.draw(context, this.camera);
+    this.gameState.getObjects().forEach(obj => obj.getDetail().draw(context));
+  }
+}

--- a/app/javascript/src/game/view.js
+++ b/app/javascript/src/game/view.js
@@ -1,5 +1,5 @@
-import {TextDrawer} from './drawing/textdrawer.js';
-import {Vector} from './physics/vector.js';
+import {GameUi} from './ui/gameui.js';
+
 
 export class View {
 
@@ -28,20 +28,6 @@ export class View {
     this.canvasElement.height = this.gameState.height;
   }
 
-  showFrameRate(framerate) {
-    const params = {
-      fillStyle: 'white',
-      font: "10px Arial",
-      textAlign: "left"
-    };
-    const drawer = new TextDrawer(
-      new Vector(20, 10).add(this.camera.getBounds()[0]),
-      `Framerate: ${framerate}`,
-      params
-    );
-    drawer.draw(this.context);
-  }
-
   /*
   * Calls to this method update the rendering of the game.
   * gameState provides the state to render
@@ -53,9 +39,10 @@ export class View {
     this.camera.update(this.context);
     this.updateObjectsWithFunctions(this.gameState.spaceDust, (object) => object.getDrawer().draw(this.context));
     this.updateObjectsWithFunctions(this.gameState.getObjects(),(object) => object.getDrawer().draw(this.context));
+    const gameUi = new GameUi(this.gameState, this.camera);
+    gameUi.draw(this.context);
     if(this.gameState.showDetail()) {
-      this.showFrameRate(Math.round(this.gameState.frameRate, 2));
-      this.updateObjectsWithFunctions(this.gameState.getObjects(), (object) => object.getDetail().draw(this.context));
+      gameUi.drawDetails(this.context);
     }
   }
 }

--- a/test/camera/test_camera.js
+++ b/test/camera/test_camera.js
@@ -51,10 +51,10 @@ describe('Camera', function() {
       camera.update(contextMock);
 
       // Then
-      assert.equal(camera.getBounds()[0].x, -31);
-      assert.equal(camera.getBounds()[0].y, -23);
-      assert.equal(camera.getBounds()[1].x, 609);
-      assert.equal(camera.getBounds()[1].y, 457);
+      assert.equal(camera.getBounds().topLeft.x, -31);
+      assert.equal(camera.getBounds().topLeft.y, -23);
+      assert.equal(camera.getBounds().bottomRight.x, 609);
+      assert.equal(camera.getBounds().bottomRight.y, 457);
     });
   });
 });

--- a/test/entities/test_dustparticle.js
+++ b/test/entities/test_dustparticle.js
@@ -1,5 +1,6 @@
 import {DustParticle} from '../../app/javascript/src/game/entities/dustparticle.js';
 import { Vector } from '../../app/javascript/src/game/physics/vector.js';
+import { Bounds } from '../../app/javascript/src/game/physics/bounds.js';
 
 const assert = require('assert');
 
@@ -8,10 +9,10 @@ describe('DustParticle', function() {
     it('Should update the position of the dustparticle', function() {
       // Given
       const delta = new Vector(10, 10),
-        bounds = [
+        bounds = new Bounds(
           new Vector(0, 0),
           new Vector(140, 140)
-        ];
+        );
       const dust = new DustParticle();
 
       // When

--- a/test/physics/test_bounds.js
+++ b/test/physics/test_bounds.js
@@ -1,0 +1,88 @@
+import {Bounds} from '../../app/javascript/src/game/physics/bounds.js';
+import {Vector} from '../../app/javascript/src/game/physics/vector.js';
+
+const assert = require('assert');
+
+describe('Bounds', function() {
+  describe('#wrapBounds', function() {
+    it('Should return a vector within the given bounds, by "wrapping" from one edge to another ', function() {
+      // Given
+      const topLeft = new Vector(0, 0);
+      const bottomRight = new Vector(5, 5);
+      const bounds = new Bounds(topLeft, bottomRight);
+
+      // When
+      const testVector = new Vector(10, 10);
+      const newVector = bounds.wrapBounds(testVector);
+
+      // Then
+      assert(newVector.x <= bottomRight.x);
+      assert(newVector.y <= bottomRight.y);
+      assert(newVector.x >= topLeft.x);
+      assert(newVector.y >= topLeft.y);
+    });
+
+    it('Should return the same vector object if it is in bounds', function() {
+      // Given
+      const topLeft = new Vector(0, 0);
+      const bottomRight = new Vector(5, 5);
+      const bounds = new Bounds(topLeft, bottomRight);
+
+      // When
+      const testVector = new Vector(3, 3);
+      const newVector = bounds.wrapBounds(testVector);
+
+      // Then
+      assert(newVector == testVector);
+    });
+  });
+
+  describe('#vectorWithinBounds', function() {
+    it('Should return a new vector at a random position within the given bounds', function() {
+      // Given
+      const topLeft = new Vector(0, 0);
+      const bottomRight = new Vector(5, 5);
+      const bounds = new Bounds(topLeft, bottomRight);
+
+      // When
+      const newVector = bounds.vectorWithinBounds();
+
+      // Then
+      assert(newVector.x <= bottomRight.x);
+      assert(newVector.y <= bottomRight.y);
+      assert(newVector.x >= topLeft.x);
+      assert(newVector.y >= topLeft.y);
+    });
+  });
+
+  describe('#inBounds', function() {
+    it('Should return true if the given vector is within the given bounds', function() {
+      // Given
+      const topLeft = new Vector(0, 0);
+      const bottomRight = new Vector(5, 5);
+      const bounds = new Bounds(topLeft, bottomRight);
+
+      // When
+      const testVector = new Vector(3, 3);
+
+      // Then
+      assert(bounds.inBounds(testVector));
+    });
+  });
+
+  describe('#centrePoint', function() {
+    it('Should return a vector representing the centre point of these bounds', function() {
+      // Given
+      const topLeft = new Vector(0, 0);
+      const bottomRight = new Vector(5, 5);
+      const bounds = new Bounds(topLeft, bottomRight);
+
+      // When
+      const testVector = bounds.centrePoint();
+
+      // Then
+      assert.equal(testVector.x, 2.5);
+      assert.equal(testVector.y, 2.5);
+    });
+  })
+})

--- a/test/physics/test_vector.js
+++ b/test/physics/test_vector.js
@@ -206,41 +206,16 @@ describe('Vector', function() {
     });
   });
 
-  describe('#wrapBounds', function() {
-    it('Should return a vector within the given bounds, by "wrapping" from one edge to another', function() {
+  describe('#angle', function() {
+    it('Should return the angle of the vector', function() {
       // Given
-      let vector = new Vector(5, 5);
-      const bounds = [
-        new Vector(10, 10),
-        new Vector(30, 30)
-      ];
-      
-      // When
-      vector = vector.wrapBounds(bounds);
+      const vector = new Vector(5, 5);
+
+      // When 
+      const angle = vector.angle();
 
       // Then
-      assert.equal(vector.x, 30);
-      assert.equal(vector.y, 30);
-    });
-  });
-
-  describe('#inBounds', function() {
-    it('Should return a new vector within the given bounds', function() {
-      // Given
-      const bounds = [
-        new Vector(10, 10),
-        new Vector(30, 30)
-      ];
-      
-      // When
-      const vector = Vector.inBounds(bounds);
-
-      // Then
-      assert(vector.x > bounds[0].x);
-      assert(vector.y > bounds[0].y);
-      assert(vector.x < bounds[1].x);
-      assert(vector.y < bounds[1].y);
-
+      assert.equal(angle * 180 / Math.PI, 45);
     });
   })
 });

--- a/test/test_view.js
+++ b/test/test_view.js
@@ -11,7 +11,7 @@ describe('View', function() {
       const height = Math.ceil(Math.random() * 500);
       const canvasSpy = getMockCanvas();
       const gameState = getMockGameState(canvasSpy, width, height);
-      const view = new View(gameState, {update: sinon.spy()});
+      const view = new View(gameState, {update: sinon.spy(), getBounds: sinon.spy()});
 
       // When
       view.update();
@@ -27,7 +27,7 @@ describe('View', function() {
       const height = Math.ceil(Math.random() * 500);
       const canvasSpy = getMockCanvas();
       const gameState = getMockGameState(canvasSpy, width, height);
-      const view = new View(gameState, {update: sinon.spy()});
+      const view = new View(gameState, {update: sinon.spy(), getBounds: sinon.spy()});
 
       // When
       view.update();
@@ -44,7 +44,7 @@ describe('View', function() {
       const drawer = {draw: sinon.spy()};
       objects.push({getDrawer: function() {return drawer;}});
       const gameState = getMockWithObjects(canvasSpy, objects);
-      const view = new View(gameState, {update: sinon.spy()});
+      const view = new View(gameState, {update: sinon.spy(), getBounds: sinon.spy()});
 
       // When 
       view.update();


### PR DESCRIPTION
#### What's this PR do?
Adds arrows at the edge of the visible play area to show where other player ships are.
Introduces the idea of "bounds" (which can probably be incorporated into/replaced with bounding box in the future)

##### Background context
Now players are able to find other players when they're not in the current user visible play area

#### Where should the reviewer start?
bounds.js <- is basically a rectangle that consists of two vectors, topLeft and bottomRight

#### How should this be manually tested?
Test with multiple ships, more than one ship does not produce more arrows, instead a number of ships in that direction are shown.

#### Screenshots
![arrows-again](https://user-images.githubusercontent.com/2657482/55281804-fb8bdf80-5339-11e9-9bcf-7f8b1cc3e39a.gif)


Fixes #97 and #99 