### PR TITLE
Player remove - should be merged after #96

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -39,6 +39,7 @@ module Hammeroids
           end
 
           connection.onclose do
+            Hammeroids::Channels::Remove.new(channel, player.id).broadcast
             player.delete
             Hammeroids::Channels::Lobby.new(channel).broadcast
           end

--- a/app/javascript/src/game/sockets/message_router.js
+++ b/app/javascript/src/game/sockets/message_router.js
@@ -2,12 +2,14 @@ import {Lobby} from '../ui/lobby.js';
 import {Update} from './messages/update.js';
 import {Munitions} from './messages/munitions.js';
 import {PlayerName} from './messages/player_name.js';
+import {Remove} from './messages/remove.js';
 
 const CLASSES = {
   'lobby': Lobby,
   'update': Update,
   'munitions': Munitions,
-  'welcome': PlayerName
+  'welcome': PlayerName,
+  'remove': Remove
 };
 
 export class MessageRouter {

--- a/app/javascript/src/game/sockets/messages/remove.js
+++ b/app/javascript/src/game/sockets/messages/remove.js
@@ -1,0 +1,10 @@
+export class Remove {
+  constructor(payload, socket) {
+    this.payload = payload;
+    this.socket = socket;
+  }
+
+  update() {
+    delete this.socket.networkObjects[this.payload.id];
+  }
+}

--- a/app/lib/channels/remove.rb
+++ b/app/lib/channels/remove.rb
@@ -1,0 +1,25 @@
+module Hammeroids
+  module Channels
+    # Broadcasts player removal
+    class Remove
+      def initialize(channel, id)
+        @channel = channel
+        @id = id
+      end
+
+      def broadcast
+        @channel.push(to_json)
+      end
+
+      private
+
+      def attributes
+        { type: "remove", payload: { id: @id } }
+      end
+
+      def to_json
+        JSON.generate(attributes)
+      end
+    end
+  end
+end

--- a/spec/lib/channels/remove_spec.rb
+++ b/spec/lib/channels/remove_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Hammeroids::Channels::Remove do
+  describe "#broadcast" do
+    subject { described_class.new(channel, id).broadcast }
+
+    context "channel" do
+      let(:channel) { instance_double("EM::Channel", push: nil) }
+      let(:id) { Faker::Number.number(1).to_i }
+
+      it "pushes remove JSON to channel" do
+        subject
+        expect(channel).to have_received(:push).with("{\"type\":\"remove\",\"payload\":{\"id\":#{id}}}")
+      end
+    end
+  end
+end

--- a/test/entities/test_dustparticle.js
+++ b/test/entities/test_dustparticle.js
@@ -19,10 +19,10 @@ describe('DustParticle', function() {
 
       // Then
       const errorMessage = `Dust position was ${dust.position.toString()}`;
-      assert(dust.position.x > 0, errorMessage);
-      assert(dust.position.x < 140, errorMessage);
-      assert(dust.position.y > 0, errorMessage);
-      assert(dust.position.y < 140, errorMessage);
+      assert(dust.position.x >= 0, errorMessage);
+      assert(dust.position.x <= 140, errorMessage);
+      assert(dust.position.y >= 0, errorMessage);
+      assert(dust.position.y <= 140, errorMessage);
     });
   });
 });

--- a/test/sockets/test_remove.js
+++ b/test/sockets/test_remove.js
@@ -1,0 +1,24 @@
+import {Remove} from '../../app/javascript/src/game/sockets/messages/remove.js';
+
+const assert = require('assert');
+
+describe('Remove', function() {
+  describe('#update', function() {
+    it('Should remove the ship with the given player id from the sockets network objects store', function() {
+      // Given
+      const socket = {
+        networkObjects: {
+            1: "test"
+        }
+      };
+      const payload = {'id': 1}
+      const remove = new Remove(payload, socket);
+
+      // When
+      remove.update();
+
+      // Then
+      assert(socket.networkObjects[1] == undefined);
+    });
+  });
+});


### PR DESCRIPTION
#### What's this PR do?
Creates a message that is sent when a player disconnects.

##### Background context
Removes network ships from game model so they're no longer drawn

#### Where should the reviewer start?
remove.js and remove.rb
subscription.rb <- I changed how the ID is fetched, stopping the channel from being subscribed to twice

#### How should this be manually tested?
Join the game twice, leave with one player, that player will no longer be drawn on other connected games

fixes #101 