### PR TITLE
Memoize subscription ID to prevent duplicate subscriptions.

### DIFF
--- a/app/lib/channels/subscription.rb
+++ b/app/lib/channels/subscription.rb
@@ -20,7 +20,7 @@ module Hammeroids
       end
 
       def id
-        @channel.subscribe { |message| @connection.send(message) }
+        @id ||= @channel.subscribe { |message| @connection.send(message) }
       end
 
       def json


### PR DESCRIPTION
#### What's this PR do?

Memoizes the subscription ID to prevent doubling of subscriptions.
